### PR TITLE
fix(yolo-tracker): use local implementations instead of sports.common for Python 3.13 compat

### DIFF
--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/utils/__init__.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/utils/__init__.py
@@ -1,8 +1,44 @@
-"""Utility modules for YOLO Tracker."""
+"""Utility modules for YOLO Tracker.
+
+This package provides utilities for sports tracking:
+- create_batches - Batch generation utility
+- TeamClassifier - Team classification with umap fallback for Python 3.13
+- ViewTransformer - View transformation with 4-point validation
+- ball.py - Ball tracking (not annotating)
+- soccer_pitch.py - Soccer pitch drawing utilities
+- annotators.py - Custom annotators
+- tracking.py - Tracking utilities
+- transforms.py - Image transforms
+- common.py - Common utilities
+
+Note: roboflow/sports is not used directly due to Python 3.13 incompatibility
+(umap-learn requires Python < 3.10). Local implementations mirror sports.common
+with necessary modifications.
+"""
+
+from .team import create_batches, TeamClassifier
+from .view import ViewTransformer
+
+from . import (
+    transforms,
+    annotators,
+    tracking,
+    common,
+    ball,
+    soccer_pitch,
+)
 
 __all__ = [
+    # From team.py (local implementation with umap fallback)
+    "create_batches",
+    "TeamClassifier",
+    # From view.py (local implementation with 4-point validation)
+    "ViewTransformer",
+    # Custom forgeSYTE modules
     "transforms",
     "annotators",
     "tracking",
     "common",
+    "ball",
+    "soccer_pitch",
 ]


### PR DESCRIPTION
The roboflow/sports package cannot be used on Python 3.13 due to umap-learn dependency (requires Python < 3.10). This PR updates utils/__init__.py to import from local modules instead of sports.common.

## Changes
- Update utils/__init__.py to import from local modules instead of sports.common
- Keep team.py with umap fallback for Python 3.13
- Keep view.py with 4-point validation

## Testing
- All 73 tests pass (15 model tests skipped as expected)

Closes #27