### PR TITLE
docs(yolo-tracker): document sports.compat decision

### DIFF
--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/utils/__init__.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/utils/__init__.py
@@ -1,9 +1,13 @@
 """Utility modules for YOLO Tracker.
 
 This package provides utilities for sports tracking:
+
+Core Classes:
 - create_batches - Batch generation utility
-- TeamClassifier - Team classification with umap fallback for Python 3.13
-- ViewTransformer - View transformation with 4-point validation
+- TeamClassifier - Team classification (based on sports.common with umap fallback)
+- ViewTransformer - View transformation (based on sports.common with 4-point validation)
+
+Custom Modules:
 - ball.py - Ball tracking (not annotating)
 - soccer_pitch.py - Soccer pitch drawing utilities
 - annotators.py - Custom annotators
@@ -11,9 +15,13 @@ This package provides utilities for sports tracking:
 - transforms.py - Image transforms
 - common.py - Common utilities
 
-Note: roboflow/sports is not used directly due to Python 3.13 incompatibility
-(umap-learn requires Python < 3.10). Local implementations mirror sports.common
-with necessary modifications.
+Note on sports.common:
+The roboflow/sports package has a Python version check bug that prevents
+installation on Python 3.10+ despite setup.py stating python_requires>=3.8.
+Local implementations are used instead, which mirror sports.common (MIT License)
+with forgeSYTE-specific improvements:
+- umap fallback for Python 3.13 compatibility
+- 4-point validation for homography calculation
 """
 
 from .team import create_batches, TeamClassifier


### PR DESCRIPTION
Document the decision to use local implementations instead of sports.common.

## Background
The roboflow/sports package has a Python version check bug:
- setup.py states 
- But build script checks for 
- This prevents installation on Python 3.10+

## Decision
Keep local implementations that mirror sports.common (MIT License) with forgeSYTE improvements:
- umap fallback for Python 3.13 compatibility
- 4-point validation for homography calculation

## Changes
- Updated utils/__init__.py docstring with detailed explanation

## Testing
- All 73 tests pass (15 model tests skipped as expected)

Refs #29