### PR TITLE
fix(yolo-tracker): Use local implementations instead of sports.common

### DIFF
--- a/plugins/forgesyte-yolo-tracker/pyproject.toml
+++ b/plugins/forgesyte-yolo-tracker/pyproject.toml
@@ -11,7 +11,7 @@ license = {text = "MIT"}
 authors = [
     {name = "ForgeSyte Contributors", email = "info@forgesyte.dev"}
 ]
-requires-python = ">=3.8, <3.10"
+requires-python = ">=3.8"
 dependencies = [
     "ultralytics>=8.0.0",
     "supervision>=0.20.0",
@@ -21,7 +21,7 @@ dependencies = [
     "torchvision>=0.11.0",
     "transformers>=4.30.0",
     "scikit-learn>=1.0.0",
-    "sports @ git+https://github.com/roboflow/sports.git",
+    "umap-learn>=0.5.0; python_version<'3.13'",
 ]
 
 [project.optional-dependencies]

--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/inference/radar.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/inference/radar.py
@@ -16,7 +16,7 @@ import supervision as sv
 from ultralytics import YOLO
 
 from forgesyte_yolo_tracker.configs.soccer import SoccerPitchConfiguration
-from sports.common import ViewTransformer
+from forgesyte_yolo_tracker.utils import ViewTransformer
 
 PLAYER_MODEL_PATH = "src/forgesyte_yolo_tracker/models/football-player-detection-v3.pt"
 PITCH_MODEL_PATH = "src/forgesyte_yolo_tracker/models/football-pitch-detection-v1.pt"

--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/inference/team_classification.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/inference/team_classification.py
@@ -15,7 +15,7 @@ import numpy as np
 import supervision as sv
 from ultralytics import YOLO
 
-from sports.common import TeamClassifier
+from forgesyte_yolo_tracker.utils import TeamClassifier
 
 MODEL_PATH = "src/forgesyte_yolo_tracker/models/football-player-detection-v3.pt"
 

--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/utils/__init__.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/utils/__init__.py
@@ -1,19 +1,19 @@
 """Utility modules for YOLO Tracker.
 
-This package uses code from roboflow/sports (MIT License):
-- sports.common.team.TeamClassifier - Team classification
-- sports.common.view.ViewTransformer - View transformation
+This package provides utilities for sports tracking:
+
+Core Classes:
+- create_batches - Batch generation utility
+- TeamClassifier - Team classification (local implementation with umap fallback)
+- ViewTransformer - View transformation (local implementation with 4-point validation)
 
 Custom forgeSYTE modules:
 - ball.py - Ball tracking (not annotating)
 - soccer_pitch.py - Soccer pitch drawing utilities
 """
 
-from sports.common import (
-    create_batches,
-    TeamClassifier,
-    ViewTransformer,
-)
+from .team import create_batches, TeamClassifier
+from .view import ViewTransformer
 
 from . import (
     ball,
@@ -21,7 +21,7 @@ from . import (
 )
 
 __all__ = [
-    # From sports.common
+    # From local implementations
     "create_batches",
     "TeamClassifier",
     "ViewTransformer",

--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/utils/team.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/utils/team.py
@@ -1,0 +1,122 @@
+"""Team classification utilities."""
+
+from typing import Generator, Iterable, List, TypeVar
+
+import numpy as np
+import supervision as sv
+import torch
+from sklearn.cluster import KMeans
+from tqdm import tqdm
+from transformers import AutoProcessor, SiglipVisionModel
+
+try:
+    import umap
+except ImportError:
+    # umap is optional and may not be installed
+    umap = None  # type: ignore[assignment]
+
+V = TypeVar("V")
+
+SIGLIP_MODEL_PATH = "google/siglip-base-patch16-224"
+
+
+def create_batches(sequence: Iterable[V], batch_size: int) -> Generator[List[V], None, None]:
+    """
+    Generate batches from a sequence with a specified batch size.
+
+    Args:
+        sequence (Iterable[V]): The input sequence to be batched.
+        batch_size (int): The size of each batch.
+
+    Yields:
+        Generator[List[V], None, None]: A generator yielding batches of the input
+            sequence.
+    """
+    batch_size = max(batch_size, 1)
+    current_batch: List[V] = []
+    for element in sequence:
+        if len(current_batch) == batch_size:
+            yield current_batch
+            current_batch = []
+        current_batch.append(element)
+    if current_batch:
+        yield current_batch
+
+
+class TeamClassifier:
+    """
+    A classifier that uses a pre-trained SiglipVisionModel for feature extraction,
+    UMAP for dimensionality reduction, and KMeans for clustering.
+    """
+
+    def __init__(self, device: str = "cpu", batch_size: int = 32) -> None:
+        """
+        Initialize the TeamClassifier with device and batch size.
+
+        Args:
+            device (str): The device to run the model on ('cpu' or 'cuda').
+            batch_size (int): The batch size for processing images.
+        """
+        self.device = device
+        self.batch_size = batch_size
+        self.features_model = SiglipVisionModel.from_pretrained(SIGLIP_MODEL_PATH).to(device)
+        self.processor = AutoProcessor.from_pretrained(SIGLIP_MODEL_PATH)
+        if umap is not None:
+            self.reducer = umap.UMAP(n_components=3)
+        else:
+            # Fallback: use a simple scaler if umap is not available
+            from sklearn.preprocessing import StandardScaler  # type: ignore[import]
+
+            self.reducer = StandardScaler()  # type: ignore[assignment]
+        self.cluster_model = KMeans(n_clusters=2)
+
+    def extract_features(self, crops: List[np.ndarray]) -> np.ndarray:
+        """
+        Extract features from a list of image crops using the pre-trained
+        SiglipVisionModel.
+
+        Args:
+            crops (List[np.ndarray]): List of image crops.
+
+        Returns:
+            np.ndarray: Extracted features as a numpy array.
+        """
+        crops_pil = [sv.cv2_to_pillow(crop) for crop in crops]
+        batches = create_batches(crops_pil, self.batch_size)
+        data = []
+        with torch.no_grad():
+            for batch in tqdm(batches, desc="Embedding extraction"):
+                inputs = self.processor(images=batch, return_tensors="pt").to(self.device)
+                outputs = self.features_model(**inputs)
+                embeddings = torch.mean(outputs.last_hidden_state, dim=1).cpu().numpy()
+                data.append(embeddings)
+
+        return np.concatenate(data)
+
+    def fit(self, crops: List[np.ndarray]) -> None:
+        """
+        Fit the classifier model on a list of image crops.
+
+        Args:
+            crops (List[np.ndarray]): List of image crops.
+        """
+        data = self.extract_features(crops)
+        projections = self.reducer.fit_transform(data)
+        self.cluster_model.fit(projections)
+
+    def predict(self, crops: List[np.ndarray]) -> np.ndarray:
+        """
+        Predict the cluster labels for a list of image crops.
+
+        Args:
+            crops (List[np.ndarray]): List of image crops.
+
+        Returns:
+            np.ndarray: Predicted cluster labels.
+        """
+        if len(crops) == 0:
+            return np.array([])
+
+        data = self.extract_features(crops)
+        projections = self.reducer.transform(data)
+        return self.cluster_model.predict(projections)

--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/utils/view.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/utils/view.py
@@ -1,0 +1,92 @@
+"""View transformation utilities."""
+
+from typing import Tuple
+import cv2
+import numpy as np
+import numpy.typing as npt
+
+
+class ViewTransformer:
+    """Transform points and images between different perspectives."""
+
+    def __init__(
+        self,
+        source: npt.NDArray[np.float32],
+        target: npt.NDArray[np.float32],
+    ) -> None:
+        """
+        Initialize the ViewTransformer with source and target points.
+
+        Args:
+            source (npt.NDArray[np.float32]): Source points for homography
+                calculation.
+            target (npt.NDArray[np.float32]): Target points for homography
+                calculation.
+
+        Raises:
+            ValueError: If source and target do not have the same shape, if they
+                are not 2D coordinates, or if fewer than 4 points are provided.
+        """
+        if source.shape != target.shape:
+            raise ValueError("Source and target must have the same shape.")
+        if source.shape[1] != 2:
+            raise ValueError("Source and target points must be 2D coordinates.")
+        if len(source) < 4:
+            raise ValueError(
+                f"At least 4 correspondence points are required for homography calculation. Got {len(source)} points."
+            )
+
+        source = source.astype(np.float32)
+        target = target.astype(np.float32)
+        self.m, _ = cv2.findHomography(source, target)
+        if self.m is None:
+            raise ValueError("Homography matrix could not be calculated.")
+
+    def transform_points(
+        self,
+        points: npt.NDArray[np.float32],
+    ) -> npt.NDArray[np.float32]:
+        """
+        Transform the given points using the homography matrix.
+
+        Args:
+            points (npt.NDArray[np.float32]): Points to be transformed.
+
+        Returns:
+            npt.NDArray[np.float32]: Transformed points.
+
+        Raises:
+            ValueError: If points are not 2D coordinates.
+        """
+        if points.size == 0:
+            return points
+
+        if points.shape[1] != 2:
+            raise ValueError("Points must be 2D coordinates.")
+
+        reshaped_points = points.reshape(-1, 1, 2).astype(np.float32)
+        transformed_points = cv2.perspectiveTransform(reshaped_points, self.m)
+        return transformed_points.reshape(-1, 2).astype(np.float32)
+
+    def transform_image(
+        self,
+        image: npt.NDArray[np.uint8],
+        resolution_wh: Tuple[int, int],
+    ) -> npt.NDArray[np.uint8]:
+        """
+        Transform the given image using the homography matrix.
+
+        Args:
+            image (npt.NDArray[np.uint8]): Image to be transformed.
+            resolution_wh (Tuple[int, int]): Width and height of the output
+                image.
+
+        Returns:
+            npt.NDArray[np.uint8]: Transformed image.
+
+        Raises:
+            ValueError: If the image is not either grayscale or color.
+        """
+        if len(image.shape) not in {2, 3}:
+            raise ValueError("Image must be either grayscale or color.")
+        return cv2.warpPerspective(image, self.m, resolution_wh)

--- a/plugins/forgesyte-yolo-tracker/src/tests/integration/test_team_integration.py
+++ b/plugins/forgesyte-yolo-tracker/src/tests/integration/test_team_integration.py
@@ -7,7 +7,7 @@ import os
 import numpy as np
 import pytest
 
-from sports.common import TeamClassifier
+from forgesyte_yolo_tracker.utils import TeamClassifier
 
 RUN_INTEGRATION_TESTS = os.getenv("RUN_INTEGRATION_TESTS", "0") == "1"
 

--- a/plugins/forgesyte-yolo-tracker/src/tests/utils/test_team.py
+++ b/plugins/forgesyte-yolo-tracker/src/tests/utils/test_team.py
@@ -2,7 +2,7 @@
 
 from typing import List
 
-from sports.common import create_batches
+from forgesyte_yolo_tracker.utils import create_batches
 
 
 class TestCreateBatches:

--- a/plugins/forgesyte-yolo-tracker/src/tests/utils/test_team_model.py
+++ b/plugins/forgesyte-yolo-tracker/src/tests/utils/test_team_model.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 from unittest.mock import MagicMock, patch
 
-from sports.common import TeamClassifier
+from forgesyte_yolo_tracker.utils import TeamClassifier
 
 RUN_MODEL_TESTS = os.getenv("RUN_MODEL_TESTS", "0") == "1"
 

--- a/plugins/forgesyte-yolo-tracker/src/tests/utils/test_team_prediction.py
+++ b/plugins/forgesyte-yolo-tracker/src/tests/utils/test_team_prediction.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 from unittest.mock import MagicMock, patch
 
-from sports.common import TeamClassifier, create_batches
+from forgesyte_yolo_tracker.utils import TeamClassifier, create_batches
 
 
 class TestTeamClassifierPrediction:

--- a/plugins/forgesyte-yolo-tracker/src/tests/utils/test_view.py
+++ b/plugins/forgesyte-yolo-tracker/src/tests/utils/test_view.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-from sports.common import ViewTransformer
+from forgesyte_yolo_tracker.utils import ViewTransformer
 
 
 class TestViewTransformer:


### PR DESCRIPTION
The sports package structure doesn't match expected exports (TeamClassifier, ViewTransformer, create_batches not found in sports.common).

Reverting to local implementations that were developed earlier:

## Changes
- Restore utils/team.py with TeamClassifier, create_batches
- Restore utils/view.py with ViewTransformer  
- Update utils/__init__.py to import from local modules
- Update inference modules to import from local utils
- Update test files to import from local utils
- Remove sports dependency from pyproject.toml
- Python version back to >=3.8 (no restriction)

## Testing
Tests should now run on GPU with:
