### PR TITLE
fix(yolo-tracker): Remove remaining sports.common imports

### DIFF
--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/radar_video.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/radar_video.py
@@ -13,7 +13,7 @@ import supervision as sv
 from ultralytics import YOLO
 
 from forgesyte_yolo_tracker.configs.soccer import SoccerPitchConfiguration
-from sports.common import ViewTransformer
+from forgesyte_yolo_tracker.utils import ViewTransformer
 
 PLAYER_MODEL_PATH = "src/forgesyte_yolo_tracker/models/football-player-detection-v3.pt"
 PITCH_MODEL_PATH = "src/forgesyte_yolo_tracker/models/football-pitch-detection-v1.pt"

--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/team_classification_video.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/team_classification_video.py
@@ -12,7 +12,7 @@ import numpy as np
 import supervision as sv
 from ultralytics import YOLO
 
-from sports.common import TeamClassifier
+from forgesyte_yolo_tracker.utils import TeamClassifier
 
 MODEL_PATH = "src/forgesyte_yolo_tracker/models/football-player-detection-v3.pt"
 


### PR DESCRIPTION
Remove sports.common imports from 2 video modules:

- radar_video.py: import ViewTransformer from local utils
- team_classification_video.py: import TeamClassifier from local utils

All code now uses local implementations.