### PR TITLE
chore: Remove forgesyte git dependency from all plugins

### DIFF
--- a/plugins/block_mapper/pyproject.toml
+++ b/plugins/block_mapper/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "numpy>=1.24.0",
     "Pillow>=10.0.0",
     "pydantic>=2.0.0",
-    "forgesyte @ git+https://github.com/rogermt/forgesyte.git",
 ]
 
 [project.entry-points."forgesyte.plugins"]

--- a/plugins/moderation/pyproject.toml
+++ b/plugins/moderation/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "numpy>=1.24.0",
     "Pillow>=10.0.0",
     "pydantic>=2.0.0",
-    "forgesyte @ git+https://github.com/rogermt/forgesyte.git",
 ]
 
 [project.entry-points."forgesyte.plugins"]

--- a/plugins/motion_detector/pyproject.toml
+++ b/plugins/motion_detector/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "numpy>=1.24.0",
     "Pillow>=10.0.0",
     "pydantic>=2.0.0",
-    "forgesyte @ git+https://github.com/rogermt/forgesyte.git",
 ]
 
 [project.optional-dependencies]

--- a/plugins/ocr/pyproject.toml
+++ b/plugins/ocr/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "Pillow>=10.0.0",
     "pytesseract>=0.3.10",
     "pydantic>=2.0.0",
-    "forgesyte @ git+https://github.com/rogermt/forgesyte.git",
 ]
 
 [project.optional-dependencies]

--- a/plugins/plugin_template/pyproject.toml
+++ b/plugins/plugin_template/pyproject.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 description = "Template plugin for ForgeSyte"
 dependencies = [
     "pydantic>=2.12.5",
-    "forgesyte @ git+https://github.com/rogermt/forgesyte.git",
 ]
 
 [project.entry-points."forgesyte.plugins"]


### PR DESCRIPTION
## Summary

Remove `forgesyte @ git+https://github.com/rogermt/forgesyte.git` dependency from all plugins.

The dependency is not needed until forgesyte git is PyPI-installable. Plugins import from `app.models` which is available at runtime in the ForgeSyte server.

## Plugins Updated

| Plugin | Status |
|--------|--------|
| block_mapper | ✅ Removed |
| moderation | ✅ Removed |
| motion_detector | ✅ Removed |
| ocr | ✅ Removed |
| plugin_template | ✅ Removed |
| forgesyte-yolo-tracker | ✅ Already didn't have it |

## Why

The git dependency was added to allow plugin installation outside the ForgeSyte server. However, since forgesyte is not yet PyPI-installable, this dependency fails to build.

Removing it allows:
- Plugins to be installed locally
- Tests to run without network dependencies
- Clean migration to PyPI-based dependency when ready

## Verification

```bash
# Verify no plugins have the git dependency
grep -r "forgesyte @ git" plugins/*/pyproject.toml
# Should return nothing

# Verify imports still exist (needed at runtime)
grep -r "from app.models" plugins/*/src/*/plugin.py
# Should find 6 matches (all plugins)
```

## Checklist

- [x] All 5 plugins updated
- [x] Tests still pass (no network dependency needed)
- [x] Imports preserved (app.models available at runtime)