### PR TITLE
fix(yolo-tracker): Fix hardcoded model paths in video modules

### DIFF
--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/ball_detection_video.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/ball_detection_video.py
@@ -5,13 +5,17 @@ Roboflow-style full video processing:
 - run_ball_detection_video_frames(): Generator yielding annotated frames
 """
 
+from pathlib import Path
 from typing import Iterator, Optional
 
 import numpy as np
 import supervision as sv
 from ultralytics import YOLO
 
-MODEL_PATH = "src/forgesyte_yolo_tracker/models/football-ball-detection-v2.pt"
+from forgesyte_yolo_tracker.configs import get_model_path
+
+MODEL_NAME = get_model_path("ball_detection")
+MODEL_PATH = str(Path(__file__).parents[2] / "models" / MODEL_NAME)
 BALL_COLOR = sv.Color.from_hex("#FF6347")
 DEFAULT_CONFIDENCE = 0.20
 

--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/pitch_detection_video.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/pitch_detection_video.py
@@ -5,6 +5,7 @@ Roboflow-style full video processing:
 - run_pitch_detection_video_frames(): Generator yielding annotated frames
 """
 
+from pathlib import Path
 from typing import Iterator, Optional
 
 import cv2
@@ -13,8 +14,10 @@ import supervision as sv
 from ultralytics import YOLO
 
 from forgesyte_yolo_tracker.configs.soccer import SoccerPitchConfiguration
+from forgesyte_yolo_tracker.configs import get_model_path
 
-MODEL_PATH = "src/forgesyte_yolo_tracker/models/football-pitch-detection-v1.pt"
+MODEL_NAME = get_model_path("pitch_detection")
+MODEL_PATH = str(Path(__file__).parents[2] / "models" / MODEL_NAME)
 CONFIG = SoccerPitchConfiguration()
 
 PITCH_COLOR = sv.Color.from_hex("#00FF00")

--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/player_detection_video.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/player_detection_video.py
@@ -5,6 +5,7 @@ Roboflow-style full video processing:
 - run_player_detection_video_frames(): Generator yielding annotated frames
 """
 
+from pathlib import Path
 from typing import Iterator, Optional
 
 import numpy as np
@@ -12,8 +13,10 @@ import supervision as sv
 from ultralytics import YOLO
 
 from forgesyte_yolo_tracker.configs.soccer import SoccerPitchConfiguration
+from forgesyte_yolo_tracker.configs import get_model_path
 
-MODEL_PATH = "src/forgesyte_yolo_tracker/models/football-player-detection-v3.pt"
+MODEL_NAME = get_model_path("player_detection")
+MODEL_PATH = str(Path(__file__).parents[2] / "models" / MODEL_NAME)
 CONFIG = SoccerPitchConfiguration()
 
 CLASS_NAMES = {0: "player", 1: "goalkeeper", 2: "referee"}

--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/player_tracking_video.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/player_tracking_video.py
@@ -5,13 +5,17 @@ Roboflow-style full video processing with ByteTrack:
 - run_player_tracking_video_frames(): Generator yielding annotated frames
 """
 
+from pathlib import Path
 from typing import Iterator, Optional
 
 import numpy as np
 import supervision as sv
 from ultralytics import YOLO
 
-MODEL_PATH = "src/forgesyte_yolo_tracker/models/football-player-detection-v3.pt"
+from forgesyte_yolo_tracker.configs import get_model_path
+
+MODEL_NAME = get_model_path("player_detection")
+MODEL_PATH = str(Path(__file__).parents[2] / "models" / MODEL_NAME)
 
 CLASS_NAMES = {0: "player", 1: "goalkeeper", 2: "referee"}
 TRACK_COLORS = sv.ColorPalette.from_hex(["#00BFFF", "#FFD700", "#FF6347"])

--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/radar_video.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/radar_video.py
@@ -5,6 +5,7 @@ Roboflow-style full video processing:
 - run_radar_video_frames(): Generator yielding frames with radar
 """
 
+from pathlib import Path
 from typing import Iterator, Optional, Tuple
 
 import cv2
@@ -14,9 +15,12 @@ from ultralytics import YOLO
 
 from forgesyte_yolo_tracker.configs.soccer import SoccerPitchConfiguration
 from forgesyte_yolo_tracker.utils import ViewTransformer
+from forgesyte_yolo_tracker.configs import get_model_path
 
-PLAYER_MODEL_PATH = "src/forgesyte_yolo_tracker/models/football-player-detection-v3.pt"
-PITCH_MODEL_PATH = "src/forgesyte_yolo_tracker/models/football-pitch-detection-v1.pt"
+PLAYER_MODEL_NAME = get_model_path("player_detection")
+PLAYER_MODEL_PATH = str(Path(__file__).parents[2] / "models" / PLAYER_MODEL_NAME)
+PITCH_MODEL_NAME = get_model_path("pitch_detection")
+PITCH_MODEL_PATH = str(Path(__file__).parents[2] / "models" / PITCH_MODEL_NAME)
 CONFIG = SoccerPitchConfiguration()
 
 TEAM_A_COLOR = (0, 191, 255)

--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/team_classification_video.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/team_classification_video.py
@@ -5,6 +5,7 @@ Roboflow-style full video processing:
 - run_team_classification_video_frames(): Generator yielding annotated frames
 """
 
+from pathlib import Path
 from typing import Iterator, Optional
 
 import numpy as np
@@ -12,8 +13,10 @@ import supervision as sv
 from ultralytics import YOLO
 
 from forgesyte_yolo_tracker.utils import TeamClassifier
+from forgesyte_yolo_tracker.configs import get_model_path
 
-MODEL_PATH = "src/forgesyte_yolo_tracker/models/football-player-detection-v3.pt"
+MODEL_NAME = get_model_path("player_detection")
+MODEL_PATH = str(Path(__file__).parents[2] / "models" / MODEL_NAME)
 
 TEAM_A_COLOR = sv.Color.from_hex("#00BFFF")
 TEAM_B_COLOR = sv.Color.from_hex("#FF1493")

--- a/plugins/forgesyte-yolo-tracker/src/tests/test_video_model_paths.py
+++ b/plugins/forgesyte-yolo-tracker/src/tests/test_video_model_paths.py
@@ -1,0 +1,88 @@
+"""Tests for video module model path resolution.
+
+Verifies that all video modules use correct relative paths from configs
+instead of hardcoded paths.
+"""
+
+from pathlib import Path
+
+
+class TestVideoModelPaths:
+    """Tests for video module model path resolution."""
+
+    def test_player_detection_video_model_path_is_resolved(self) -> None:
+        """Verify player detection video uses config-based model path."""
+        from forgesyte_yolo_tracker.video.player_detection_video import MODEL_PATH
+
+        assert isinstance(MODEL_PATH, str)
+        assert MODEL_PATH.endswith(".pt")
+        assert "models" in MODEL_PATH
+        assert not MODEL_PATH.startswith("src/")
+
+    def test_player_tracking_video_model_path_is_resolved(self) -> None:
+        """Verify player tracking video uses config-based model path."""
+        from forgesyte_yolo_tracker.video.player_tracking_video import MODEL_PATH
+
+        assert isinstance(MODEL_PATH, str)
+        assert MODEL_PATH.endswith(".pt")
+        assert "models" in MODEL_PATH
+        assert not MODEL_PATH.startswith("src/")
+
+    def test_ball_detection_video_model_path_is_resolved(self) -> None:
+        """Verify ball detection video uses config-based model path."""
+        from forgesyte_yolo_tracker.video.ball_detection_video import MODEL_PATH
+
+        assert isinstance(MODEL_PATH, str)
+        assert MODEL_PATH.endswith(".pt")
+        assert "models" in MODEL_PATH
+        assert not MODEL_PATH.startswith("src/")
+
+    def test_pitch_detection_video_model_path_is_resolved(self) -> None:
+        """Verify pitch detection video uses config-based model path."""
+        from forgesyte_yolo_tracker.video.pitch_detection_video import MODEL_PATH
+
+        assert isinstance(MODEL_PATH, str)
+        assert MODEL_PATH.endswith(".pt")
+        assert "models" in MODEL_PATH
+        assert not MODEL_PATH.startswith("src/")
+
+    def test_team_classification_video_model_path_is_resolved(self) -> None:
+        """Verify team classification video uses config-based model path."""
+        from forgesyte_yolo_tracker.video.team_classification_video import MODEL_PATH
+
+        assert isinstance(MODEL_PATH, str)
+        assert MODEL_PATH.endswith(".pt")
+        assert "models" in MODEL_PATH
+        assert not MODEL_PATH.startswith("src/")
+
+    def test_radar_video_player_model_path_is_resolved(self) -> None:
+        """Verify radar video player model uses config-based path."""
+        from forgesyte_yolo_tracker.video.radar_video import PLAYER_MODEL_PATH
+
+        assert isinstance(PLAYER_MODEL_PATH, str)
+        assert PLAYER_MODEL_PATH.endswith(".pt")
+        assert "models" in PLAYER_MODEL_PATH
+        assert not PLAYER_MODEL_PATH.startswith("src/")
+
+    def test_radar_video_pitch_model_path_is_resolved(self) -> None:
+        """Verify radar video pitch model uses config-based path."""
+        from forgesyte_yolo_tracker.video.radar_video import PITCH_MODEL_PATH
+
+        assert isinstance(PITCH_MODEL_PATH, str)
+        assert PITCH_MODEL_PATH.endswith(".pt")
+        assert "models" in PITCH_MODEL_PATH
+        assert not PITCH_MODEL_PATH.startswith("src/")
+
+    def test_all_video_model_paths_use_absolute_path(self) -> None:
+        """Verify all video model paths are absolute."""
+        from forgesyte_yolo_tracker.video.player_detection_video import MODEL_PATH as pd_path
+        from forgesyte_yolo_tracker.video.player_tracking_video import MODEL_PATH as pt_path
+        from forgesyte_yolo_tracker.video.ball_detection_video import MODEL_PATH as bd_path
+        from forgesyte_yolo_tracker.video.pitch_detection_video import MODEL_PATH as pit_path
+        from forgesyte_yolo_tracker.video.team_classification_video import MODEL_PATH as tc_path
+        from forgesyte_yolo_tracker.video.radar_video import PLAYER_MODEL_PATH as r_player
+        from forgesyte_yolo_tracker.video.radar_video import PITCH_MODEL_PATH as r_pitch
+
+        for path in [pd_path, pt_path, bd_path, pit_path, tc_path, r_player, r_pitch]:
+            p = Path(path)
+            assert p.is_absolute(), f"Path not absolute: {path}"


### PR DESCRIPTION
## Summary

Fix hardcoded model paths in all 6 video modules. Models directory was in wrong location and paths were not configurable.

## Changes

- player_detection_video.py: Use get_model_path() + relative path resolution
- player_tracking_video.py: Use get_model_path() + relative path resolution
- ball_detection_video.py: Use get_model_path() + relative path resolution
- pitch_detection_video.py: Use get_model_path() + relative path resolution
- team_classification_video.py: Use get_model_path() + relative path resolution
- radar_video.py: Use get_model_path() + relative path resolution for both player and pitch models
- test_video_model_paths.py: Added comprehensive tests

All modules now use config-based path resolution via `Path(__file__).parents[2] / 'models'`, matching inference module pattern.

## Testing

- [x] Tests pass (8/8 video model path tests)
- [x] Ruff lint clean
- [x] Configuration verified

## Related Issue

Fixes models directory path resolution for video processing modules.