### PR TITLE
fix(yolo-tracker): Use correct models directory path

### DIFF
--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/inference/ball_detection.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/inference/ball_detection.py
@@ -17,7 +17,7 @@ from ultralytics import YOLO
 from forgesyte_yolo_tracker.configs import get_model_path, get_confidence
 
 MODEL_NAME = get_model_path("ball_detection")
-MODEL_PATH = str(Path(__file__).parents[2] / "models" / MODEL_NAME)
+MODEL_PATH = str(Path(__file__).parent.parent / "models" / MODEL_NAME)
 DEFAULT_CONFIDENCE = get_confidence("ball")
 
 BALL_COLOR = sv.Color.from_hex("#FF6347")

--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/inference/pitch_detection.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/inference/pitch_detection.py
@@ -18,7 +18,7 @@ from forgesyte_yolo_tracker.configs.soccer import SoccerPitchConfiguration
 from forgesyte_yolo_tracker.configs import get_model_path, get_confidence
 
 MODEL_NAME = get_model_path("pitch_detection")
-MODEL_PATH = str(Path(__file__).parents[2] / "models" / MODEL_NAME)
+MODEL_PATH = str(Path(__file__).parent.parent / "models" / MODEL_NAME)
 CONFIG = SoccerPitchConfiguration()
 DEFAULT_CONFIDENCE = get_confidence("pitch")
 

--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/inference/player_detection.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/inference/player_detection.py
@@ -18,7 +18,7 @@ from forgesyte_yolo_tracker.configs.soccer import SoccerPitchConfiguration
 from forgesyte_yolo_tracker.configs import get_model_path, get_confidence
 
 MODEL_NAME = get_model_path("player_detection")
-MODEL_PATH = str(Path(__file__).parents[2] / "models" / MODEL_NAME)
+MODEL_PATH = str(Path(__file__).parent.parent / "models" / MODEL_NAME)
 CONFIG = SoccerPitchConfiguration()
 DEFAULT_CONFIDENCE = get_confidence("player")
 

--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/inference/player_tracking.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/inference/player_tracking.py
@@ -18,7 +18,7 @@ from forgesyte_yolo_tracker.configs.soccer import SoccerPitchConfiguration
 from forgesyte_yolo_tracker.configs import get_model_path, get_confidence
 
 MODEL_NAME = get_model_path("player_detection")
-MODEL_PATH = str(Path(__file__).parents[2] / "models" / MODEL_NAME)
+MODEL_PATH = str(Path(__file__).parent.parent / "models" / MODEL_NAME)
 CONFIG = SoccerPitchConfiguration()
 DEFAULT_CONFIDENCE = get_confidence("player")
 

--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/inference/radar.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/inference/radar.py
@@ -21,9 +21,9 @@ from forgesyte_yolo_tracker.configs import get_model_path, get_confidence
 from forgesyte_yolo_tracker.utils import ViewTransformer
 
 PLAYER_MODEL_NAME = get_model_path("player_detection")
-PLAYER_MODEL_PATH = str(Path(__file__).parents[2] / "models" / PLAYER_MODEL_NAME)
+PLAYER_MODEL_PATH = str(Path(__file__).parent.parent / "models" / PLAYER_MODEL_NAME)
 PITCH_MODEL_NAME = get_model_path("pitch_detection")
-PITCH_MODEL_PATH = str(Path(__file__).parents[2] / "models" / PITCH_MODEL_NAME)
+PITCH_MODEL_PATH = str(Path(__file__).parent.parent / "models" / PITCH_MODEL_NAME)
 DEFAULT_CONFIDENCE = get_confidence("pitch")
 
 TEAM_A_COLOR = (0, 191, 255)  # DeepSkyBlue BGR

--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/inference/team_classification.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/inference/team_classification.py
@@ -20,7 +20,7 @@ from forgesyte_yolo_tracker.configs import get_model_path, get_confidence
 from forgesyte_yolo_tracker.utils import TeamClassifier
 
 MODEL_NAME = get_model_path("player_detection")
-MODEL_PATH = str(Path(__file__).parents[2] / "models" / MODEL_NAME)
+MODEL_PATH = str(Path(__file__).parent.parent / "models" / MODEL_NAME)
 DEFAULT_CONFIDENCE = get_confidence("player")
 
 TEAM_A_COLOR = sv.Color.from_hex("#00BFFF")  # DeepSkyBlue

--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/ball_detection_video.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/ball_detection_video.py
@@ -15,7 +15,7 @@ from ultralytics import YOLO
 from forgesyte_yolo_tracker.configs import get_model_path
 
 MODEL_NAME = get_model_path("ball_detection")
-MODEL_PATH = str(Path(__file__).parents[2] / "models" / MODEL_NAME)
+MODEL_PATH = str(Path(__file__).parent.parent / "models" / MODEL_NAME)
 BALL_COLOR = sv.Color.from_hex("#FF6347")
 DEFAULT_CONFIDENCE = 0.20
 

--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/pitch_detection_video.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/pitch_detection_video.py
@@ -17,7 +17,7 @@ from forgesyte_yolo_tracker.configs.soccer import SoccerPitchConfiguration
 from forgesyte_yolo_tracker.configs import get_model_path
 
 MODEL_NAME = get_model_path("pitch_detection")
-MODEL_PATH = str(Path(__file__).parents[2] / "models" / MODEL_NAME)
+MODEL_PATH = str(Path(__file__).parent.parent / "models" / MODEL_NAME)
 CONFIG = SoccerPitchConfiguration()
 
 PITCH_COLOR = sv.Color.from_hex("#00FF00")

--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/player_detection_video.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/player_detection_video.py
@@ -16,7 +16,7 @@ from forgesyte_yolo_tracker.configs.soccer import SoccerPitchConfiguration
 from forgesyte_yolo_tracker.configs import get_model_path
 
 MODEL_NAME = get_model_path("player_detection")
-MODEL_PATH = str(Path(__file__).parents[2] / "models" / MODEL_NAME)
+MODEL_PATH = str(Path(__file__).parent.parent / "models" / MODEL_NAME)
 CONFIG = SoccerPitchConfiguration()
 
 CLASS_NAMES = {0: "player", 1: "goalkeeper", 2: "referee"}

--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/player_tracking_video.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/player_tracking_video.py
@@ -15,7 +15,7 @@ from ultralytics import YOLO
 from forgesyte_yolo_tracker.configs import get_model_path
 
 MODEL_NAME = get_model_path("player_detection")
-MODEL_PATH = str(Path(__file__).parents[2] / "models" / MODEL_NAME)
+MODEL_PATH = str(Path(__file__).parent.parent / "models" / MODEL_NAME)
 
 CLASS_NAMES = {0: "player", 1: "goalkeeper", 2: "referee"}
 TRACK_COLORS = sv.ColorPalette.from_hex(["#00BFFF", "#FFD700", "#FF6347"])

--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/radar_video.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/radar_video.py
@@ -18,9 +18,9 @@ from forgesyte_yolo_tracker.utils import ViewTransformer
 from forgesyte_yolo_tracker.configs import get_model_path
 
 PLAYER_MODEL_NAME = get_model_path("player_detection")
-PLAYER_MODEL_PATH = str(Path(__file__).parents[2] / "models" / PLAYER_MODEL_NAME)
+PLAYER_MODEL_PATH = str(Path(__file__).parent.parent / "models" / PLAYER_MODEL_NAME)
 PITCH_MODEL_NAME = get_model_path("pitch_detection")
-PITCH_MODEL_PATH = str(Path(__file__).parents[2] / "models" / PITCH_MODEL_NAME)
+PITCH_MODEL_PATH = str(Path(__file__).parent.parent / "models" / PITCH_MODEL_NAME)
 CONFIG = SoccerPitchConfiguration()
 
 TEAM_A_COLOR = (0, 191, 255)

--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/team_classification_video.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/video/team_classification_video.py
@@ -16,7 +16,7 @@ from forgesyte_yolo_tracker.utils import TeamClassifier
 from forgesyte_yolo_tracker.configs import get_model_path
 
 MODEL_NAME = get_model_path("player_detection")
-MODEL_PATH = str(Path(__file__).parents[2] / "models" / MODEL_NAME)
+MODEL_PATH = str(Path(__file__).parent.parent / "models" / MODEL_NAME)
 
 TEAM_A_COLOR = sv.Color.from_hex("#00BFFF")
 TEAM_B_COLOR = sv.Color.from_hex("#FF1493")

--- a/plugins/forgesyte-yolo-tracker/src/tests/test_models_directory_structure.py
+++ b/plugins/forgesyte-yolo-tracker/src/tests/test_models_directory_structure.py
@@ -1,0 +1,80 @@
+"""Tests for models directory structure and path resolution.
+
+Ensures models directory is correctly located at:
+src/forgesyte_yolo_tracker/models/ (not src/models/)
+"""
+
+from pathlib import Path
+
+
+class TestModelsDirectoryStructure:
+    """Tests for models directory structure."""
+
+    def test_models_dir_exists_at_correct_location(self) -> None:
+        """Verify models directory exists at src/forgesyte_yolo_tracker/models/."""
+        from forgesyte_yolo_tracker.configs import MODEL_CONFIG_PATH
+
+        # CONFIG_PATH should be at src/forgesyte_yolo_tracker/configs/models.yaml
+        config_path = Path(MODEL_CONFIG_PATH)
+        expected_models_dir = config_path.parent.parent / "models"
+
+        assert expected_models_dir.exists(), (
+            f"Models directory should exist at {expected_models_dir}, "
+            f"not at src/models/"
+        )
+
+    def test_models_directory_is_sibling_of_configs(self) -> None:
+        """Verify models/ is sibling to configs/ under forgesyte_yolo_tracker/."""
+        from forgesyte_yolo_tracker.configs import MODEL_CONFIG_PATH
+
+        config_dir = Path(MODEL_CONFIG_PATH).parent
+        models_dir = config_dir.parent / "models"
+
+        # Both should be under forgesyte_yolo_tracker
+        assert config_dir.name == "configs"
+        assert models_dir.name == "models"
+        assert config_dir.parent == models_dir.parent
+
+    def test_all_inference_modules_use_correct_models_path(self) -> None:
+        """Verify all inference modules resolve models path correctly."""
+        from forgesyte_yolo_tracker.inference.player_detection import MODEL_PATH as pd_path
+        from forgesyte_yolo_tracker.inference.player_tracking import MODEL_PATH as pt_path
+        from forgesyte_yolo_tracker.inference.ball_detection import MODEL_PATH as bd_path
+        from forgesyte_yolo_tracker.inference.pitch_detection import MODEL_PATH as pit_path
+        from forgesyte_yolo_tracker.inference.team_classification import MODEL_PATH as tc_path
+        from forgesyte_yolo_tracker.inference.radar import PLAYER_MODEL_PATH as r_player
+        from forgesyte_yolo_tracker.inference.radar import PITCH_MODEL_PATH as r_pitch
+
+        # All should contain "forgesyte_yolo_tracker/models"
+        paths = [pd_path, pt_path, bd_path, pit_path, tc_path, r_player, r_pitch]
+        for path in paths:
+            assert "forgesyte_yolo_tracker" in path, (
+                f"Path should contain 'forgesyte_yolo_tracker': {path}"
+            )
+            assert "models" in path, f"Path should contain 'models': {path}"
+            # Ensure it's not using wrong src/models path
+            assert "/src/models" not in path, (
+                f"Path incorrectly points to src/models: {path}"
+            )
+
+    def test_all_video_modules_use_correct_models_path(self) -> None:
+        """Verify all video modules resolve models path correctly."""
+        from forgesyte_yolo_tracker.video.player_detection_video import MODEL_PATH as pd_path
+        from forgesyte_yolo_tracker.video.player_tracking_video import MODEL_PATH as pt_path
+        from forgesyte_yolo_tracker.video.ball_detection_video import MODEL_PATH as bd_path
+        from forgesyte_yolo_tracker.video.pitch_detection_video import MODEL_PATH as pit_path
+        from forgesyte_yolo_tracker.video.team_classification_video import MODEL_PATH as tc_path
+        from forgesyte_yolo_tracker.video.radar_video import PLAYER_MODEL_PATH as r_player
+        from forgesyte_yolo_tracker.video.radar_video import PITCH_MODEL_PATH as r_pitch
+
+        # All should contain "forgesyte_yolo_tracker/models"
+        paths = [pd_path, pt_path, bd_path, pit_path, tc_path, r_player, r_pitch]
+        for path in paths:
+            assert "forgesyte_yolo_tracker" in path, (
+                f"Path should contain 'forgesyte_yolo_tracker': {path}"
+            )
+            assert "models" in path, f"Path should contain 'models': {path}"
+            # Ensure it's not using wrong src/models path
+            assert "/src/models" not in path, (
+                f"Path incorrectly points to src/models: {path}"
+            )


### PR DESCRIPTION
## Summary

Fix all inference and video modules to use the correct models directory path.

## Issue

Models were incorrectly pointing to `src/models/` instead of `src/forgesyte_yolo_tracker/models/`, which is the proper location as a sibling to the `configs/` directory.

## Changes

- Fixed model path resolution in 6 inference modules
- Fixed model path resolution in 6 video modules
- Added comprehensive test suite to validate correct paths

## Files Changed

**Inference Modules:**
- player_detection.py
- player_tracking.py
- ball_detection.py
- pitch_detection.py
- team_classification.py
- radar.py

**Video Modules:**
- player_detection_video.py
- player_tracking_video.py
- ball_detection_video.py
- pitch_detection_video.py
- team_classification_video.py
- radar_video.py

**Tests:**
- test_models_directory_structure.py (NEW)

## Testing

✅ All tests pass:
- test_models_directory_structure.py: 4/4 passed
- test_video_model_paths.py: 8/8 passed
- Ruff lint: clean

## Technical Details

Changed relative path from:
```python
Path(__file__).parents[2] / 'models' / MODEL_NAME
```

To:
```python
Path(__file__).parent.parent / 'models' / MODEL_NAME
```

This correctly resolves to `src/forgesyte_yolo_tracker/models/` from inference and video modules.