### PR TITLE
fix(yolo-tracker): Add count key to ball detection output

### DIFF
--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/inference/ball_detection.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/inference/ball_detection.py
@@ -54,9 +54,10 @@ def detect_ball_json(
 
     Returns:
         Dictionary with:
-        - detections: List of ball detections
-        - ball: Primary ball detection (or None)
+        - detections: List of ball detections with xyxy, confidence
+        - ball: Primary ball detection (highest confidence, or None)
         - ball_detected: Boolean indicating if ball was found
+        - count: Total number of detections
     """
     model = get_ball_detection_model(device=device)
     result = model(frame, imgsz=640, conf=confidence, verbose=False)[0]
@@ -82,6 +83,7 @@ def detect_ball_json(
         "detections": detection_list,
         "ball": primary_ball,
         "ball_detected": primary_ball is not None,
+        "count": len(detection_list),
     }
 
 
@@ -98,7 +100,7 @@ def detect_ball_json_with_annotated_frame(
         confidence: Detection confidence threshold
 
     Returns:
-        Dictionary with detections, ball, and annotated_frame_base64
+        Dictionary with detections, ball, ball_detected, count, and annotated_frame_base64
     """
     model = get_ball_detection_model(device=device)
     result = model(frame, imgsz=640, conf=confidence, verbose=False)[0]
@@ -130,6 +132,7 @@ def detect_ball_json_with_annotated_frame(
         "detections": detection_list,
         "ball": primary_ball,
         "ball_detected": primary_ball is not None,
+        "count": len(detection_list),
         "annotated_frame_base64": _encode_frame_to_base64(annotated),
     }
 

--- a/plugins/forgesyte-yolo-tracker/src/tests/test_inference_ball_detection.py
+++ b/plugins/forgesyte-yolo-tracker/src/tests/test_inference_ball_detection.py
@@ -2,6 +2,7 @@
 
 import pytest
 import numpy as np
+from unittest.mock import MagicMock, patch
 
 from tests.constants import RUN_MODEL_TESTS, MODELS_EXIST
 
@@ -25,7 +26,17 @@ class TestBallDetectionJSON:
         assert isinstance(result, dict)
         assert "detections" in result
 
-    def test_returns_ball_key(self) -> None:
+    def test_returns_count(self) -> None:
+        """Verify returns count of detections."""
+        from forgesyte_yolo_tracker.inference.ball_detection import detect_ball_json
+
+        frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        result = detect_ball_json(frame, device="cpu")
+
+        assert "count" in result
+        assert isinstance(result["count"], int)
+
+    def test_returns_ball(self) -> None:
         """Verify returns ball key with primary detection."""
         from forgesyte_yolo_tracker.inference.ball_detection import detect_ball_json
 
@@ -34,20 +45,61 @@ class TestBallDetectionJSON:
 
         assert "ball" in result
 
-    def test_ball_has_xyxy_and_confidence(self) -> None:
-        """Verify ball entry has xyxy and confidence."""
+    def test_returns_ball_detected(self) -> None:
+        """Verify returns ball_detected boolean."""
         from forgesyte_yolo_tracker.inference.ball_detection import detect_ball_json
 
         frame = np.zeros((480, 640, 3), dtype=np.uint8)
         result = detect_ball_json(frame, device="cpu")
 
-        if result["ball"] is not None:
-            assert "xyxy" in result["ball"]
-            assert "confidence" in result["ball"]
+        assert "ball_detected" in result
+        assert isinstance(result["ball_detected"], bool)
+
+    def test_detections_have_xyxy(self) -> None:
+        """Verify each detection has xyxy coordinates."""
+        from forgesyte_yolo_tracker.inference.ball_detection import detect_ball_json
+
+        frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        result = detect_ball_json(frame, device="cpu")
+
+        for det in result["detections"]:
+            assert "xyxy" in det
+            assert len(det["xyxy"]) == 4
+
+    def test_detections_have_confidence(self) -> None:
+        """Verify each detection has confidence score."""
+        from forgesyte_yolo_tracker.inference.ball_detection import detect_ball_json
+
+        frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        result = detect_ball_json(frame, device="cpu")
+
+        for det in result["detections"]:
+            assert "confidence" in det
+            assert 0.0 <= det["confidence"] <= 1.0
+
+    def test_ball_detected_matches_ball(self) -> None:
+        """Verify ball_detected matches if ball exists."""
+        from forgesyte_yolo_tracker.inference.ball_detection import detect_ball_json
+
+        frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        result = detect_ball_json(frame, device="cpu")
+
+        assert (result["ball_detected"] is True) == (result["ball"] is not None)
 
 
 class TestBallDetectionJSONWithAnnotated:
     """Tests for detect_ball_json_with_annotated_frame function."""
+
+    def test_returns_dict(self) -> None:
+        """Verify returns dictionary."""
+        from forgesyte_yolo_tracker.inference.ball_detection import (
+            detect_ball_json_with_annotated_frame,
+        )
+
+        frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        result = detect_ball_json_with_annotated_frame(frame, device="cpu")
+
+        assert isinstance(result, dict)
 
     def test_returns_annotated_frame_base64(self) -> None:
         """Verify returns base64 encoded annotated frame."""
@@ -60,3 +112,37 @@ class TestBallDetectionJSONWithAnnotated:
 
         assert "annotated_frame_base64" in result
         assert isinstance(result["annotated_frame_base64"], str)
+
+    def test_annotated_frame_is_valid_base64(self) -> None:
+        """Verify annotated_frame_base64 is valid base64."""
+        import base64
+
+        from forgesyte_yolo_tracker.inference.ball_detection import (
+            detect_ball_json_with_annotated_frame,
+        )
+
+        frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        result = detect_ball_json_with_annotated_frame(frame, device="cpu")
+
+        decoded = base64.b64decode(result["annotated_frame_base64"])
+        assert len(decoded) > 0
+
+
+class TestBallDetectionModelCache:
+    """Tests for model caching."""
+
+    def test_model_is_cached(self) -> None:
+        """Verify model is cached after first call."""
+        from forgesyte_yolo_tracker.inference.ball_detection import (
+            get_ball_detection_model,
+        )
+
+        with patch("forgesyte_yolo_tracker.inference.ball_detection.YOLO") as mock_yolo:
+            mock_instance = MagicMock()
+            mock_yolo.return_value = mock_instance
+
+            model1 = get_ball_detection_model(device="cpu")
+            model2 = get_ball_detection_model(device="cpu")
+
+            # Should be the same cached model
+            assert model1 is model2


### PR DESCRIPTION
## Summary

Fix ball detection API response to include missing 'count' field.

## Changes

- Add 'count' field to detect_ball_json() 
- Add 'count' field to detect_ball_json_with_annotated_frame()
- Align with player_detection response structure
- Update tests to match player detection pattern

## Testing

- Tests structure matches player_detection module
- Skipped without models (as expected)