### PR TITLE
fix: revert manifest ID to yolo-tracker (fixes #110)

### DIFF
--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/manifest.json
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/manifest.json
@@ -1,6 +1,6 @@
 {
-  "id": "forgesyte-yolo-tracker",
-  "name": "forgesyte-yolo-tracker",
+  "id": "yolo-tracker",
+  "name": "YOLO Tracker",
   "version": "1.0.0",
   "description": "ForgeSyte plugin for football player, ball, pitch, and radar analysis using YOLO + Supervision.",
   "author": "Roger",


### PR DESCRIPTION
## Summary

Fixes manifest ID mismatch that causes video tracker to fail with 'Invalid JSON from tool' error.

## Root Cause

Commit 338cd59 changed manifest ID from `"yolo-tracker"` to `"forgesyte-yolo-tracker"` but Plugin.name was not updated, causing plugin lookup failures.

## Fix

Revert manifest.json to use:
- `"id": "yolo-tracker"`
- `"name": "YOLO Tracker"`

This matches Plugin.name and entry point registration.

## Changes

- `plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/manifest.json`:
  - Changed `id` from `"forgesyte-yolo-tracker"` to `"yolo-tracker"`
  - Changed `name` from `"forgesyte-yolo-tracker"` to `"YOLO Tracker"`