### PR TITLE
test: Add Issue #110 manifest ID mismatch test

### DIFF
--- a/plugins/forgesyte-yolo-tracker/src/tests/test_manifest.py
+++ b/plugins/forgesyte-yolo-tracker/src/tests/test_manifest.py
@@ -1,9 +1,18 @@
-"""Tests for manifest file and plugin registration."""
+"""Tests for manifest file and plugin registration.
+
+Tests cover:
+- Manifest file structure and required fields
+- Plugin registration and ID consistency (Issue #110)
+- Version format validation
+- Capabilities verification
+"""
 
 import json
 from pathlib import Path
 
 import pytest
+
+from forgesyte_yolo_tracker.plugin import Plugin
 
 
 class TestManifestContent:
@@ -85,3 +94,61 @@ class TestManifestContent:
             expected_deps = ["ultralytics", "supervision", "numpy"]
             for dep in expected_deps:
                 assert dep in manifest["dependencies"]
+
+
+class TestManifestIdMatchIssue110:
+    """Test manifest ID matches Plugin.name (Issue #110).
+
+    This test catches the regression where manifest.json ID was changed from
+    'yolo-tracker' to 'forgesyte-yolo-tracker' but Plugin.name was not updated,
+    causing plugin lookup failures during server operation.
+
+    Error flow that this test prevents:
+    1. Frontend sends pluginId: "yolo-tracker"
+    2. Backend calls registry.get("yolo-tracker") -> finds plugin
+    3. Backend reads manifest.json -> finds "id": "forgesyte-yolo-tracker"
+    4. ID MISMATCH DETECTED -> error returned
+    5. Frontend fails: "Invalid JSON from tool"
+    """
+
+    @pytest.fixture
+    def plugin(self) -> Plugin:
+        """Create plugin instance for testing."""
+        return Plugin()
+
+    @pytest.fixture
+    def manifest(self) -> dict:
+        """Load the manifest file."""
+        manifest_path = Path(__file__).parent.parent / "forgesyte_yolo_tracker" / "manifest.json"
+        with open(manifest_path) as f:
+            return json.load(f)
+
+    def test_manifest_id_matches_plugin_name(
+        self, plugin: Plugin, manifest: dict
+    ) -> None:
+        """Test that manifest ID matches Plugin.name.
+
+        This is the core test for Issue #110 - it catches the mismatch
+        between the manifest.json "id" field and the Plugin.name attribute.
+
+        The server uses registry.get(plugin_name) to find plugins, then reads
+        the manifest to validate the ID. If they don't match, the lookup fails.
+
+        Expected: manifest["id"] == Plugin.name
+        """
+        manifest_id = manifest.get("id")
+        plugin_name = plugin.name
+
+        assert manifest_id == plugin_name, (
+            f"Manifest ID mismatch! "
+            f"manifest.json has id='{manifest_id}' but Plugin.name='{plugin_name}'. "
+            f"This mismatch causes plugin lookup failures. "
+            f"Please update manifest.json to have 'id': '{plugin_name}'"
+        )
+
+    def test_plugin_name_is_yolo_tracker(self, plugin: Plugin) -> None:
+        """Test that Plugin.name is the expected value 'yolo-tracker'."""
+        assert plugin.name == "yolo-tracker", (
+            f"Plugin.name should be 'yolo-tracker' but got '{plugin.name}'. "
+            f"This name is used by the frontend for API calls."
+        )


### PR DESCRIPTION
- Added TestManifestIdMatchIssue110 class with 2 tests:
  - test_manifest_id_matches_plugin_name: Catches manifest ID mismatch bug
  - test_plugin_name_is_yolo_tracker: Validates Plugin.name value

The test catches the regression where manifest.json ID was changed from 'yolo-tracker' to 'forgesyte-yolo-tracker' but Plugin.name was not updated, causing plugin lookup failures during server operation.

Test verified: Fails when manifest ID != Plugin.name with clear error message