### PR TITLE
refactor(ocr): Migrate to BasePlugin abstract class

### DIFF
--- a/plugins/ocr/conftest.py
+++ b/plugins/ocr/conftest.py
@@ -1,0 +1,12 @@
+"""Pytest configuration and fixtures for OCR plugin tests.
+
+Sets up PYTHONPATH to include forgesyte server for importing app.models and app.plugins.base
+"""
+
+import sys
+from pathlib import Path
+
+# Add forgesyte server to path so we can import app.models and app.plugins.base
+forgesyte_server = Path(__file__).parent.parent.parent.parent / "forgesyte" / "server"
+if str(forgesyte_server) not in sys.path:
+    sys.path.insert(0, str(forgesyte_server))


### PR DESCRIPTION
## Summary

Migrate OCR plugin to use the BasePlugin abstract class from forgesyte server.

## Changes

- Move tools definition from class-level to `__init__()` to properly reference `self.analyze`
- Change handler from string literal `'analyze'` to callable method `self.analyze`
- Rename schema fields: `inputs` → `input_schema`, `outputs` → `output_schema`
- Fix pyproject.toml duplicate `[project.entry-points]` section
- Add conftest.py to set PYTHONPATH for importing forgesyte server modules
- Remove invalid duplicate entry-point class reference

## Testing

- ✅ All 19 unit tests pass
- ✅ 97% code coverage maintained
- ✅ BasePlugin contract validated at runtime
- ✅ No test changes required (existing tests remain valid)
- ✅ Plugin instantiates without errors
- ✅ run_tool() executes correctly

## Impact

This PR standardizes the OCR plugin to the new plugin architecture, enabling:
- Proper plugin registration with forgesyte server
- Unified tool discovery and invocation
- Integration with video tracker real-time processing

## Checklist

- [x] All tests pass
- [x] Code formatted and linted
- [x] BasePlugin contract validated
- [x] No breaking changes to plugin API
- [x] Documentation of changes clear