### PR TITLE
fix(yolo-tracker): Fix import fallback for Kaggle/test environments

### DIFF
--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/plugin.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/plugin.py
@@ -17,8 +17,48 @@ import cv2
 import numpy as np
 import torch
 
-from app.plugins.base import BasePlugin
-from app.models import AnalysisResult, PluginMetadata
+# Try to import from ForgeSyte server, fallback for testing/Kaggle
+try:
+    from app.plugins.base import BasePlugin
+    from app.models import AnalysisResult, PluginMetadata
+except (ImportError, ModuleNotFoundError):
+    # Fallback stubs for testing/standalone environments
+    class BasePlugin:
+        """Stub BasePlugin for testing."""
+        name: str = ""
+        version: str = ""
+        description: str = ""
+        tools: Dict[str, Any] = {}
+
+        def run_tool(self, tool_name: str, args: dict) -> Dict[str, Any]:
+            raise NotImplementedError
+
+        def metadata(self) -> Dict[str, Any]:
+            return {
+                "name": self.name,
+                "version": self.version,
+                "description": self.description,
+            }
+
+        def on_load(self) -> None:
+            pass
+
+        def on_unload(self) -> None:
+            pass
+
+    class AnalysisResult:
+        """Stub AnalysisResult for testing."""
+        def __init__(self, **kwargs):
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
+        def __contains__(self, key: str) -> bool:
+            return hasattr(self, key)
+
+    class PluginMetadata(dict):
+        """Stub PluginMetadata for testing."""
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
 
 from forgesyte_yolo_tracker.configs import get_default_detections
 from forgesyte_yolo_tracker.inference.ball_detection import (


### PR DESCRIPTION
## Problem

Tests fail on Kaggle GPU with:
```
ModuleNotFoundError: No module named 'app.plugins'; 'app' is not a package
```

## Root Cause

Try/except was missing—direct import of app.plugins failed without fallback stubs.

## Solution

Wrap app.plugins imports in try/except at module level.
Provide BasePlugin, AnalysisResult, PluginMetadata stubs when import fails.

Tests now run on Kaggle without server dependency.