### PR TITLE
fix(yolo-tracker): Add metadata() with config_schema

### DIFF
--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/plugin.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/plugin.py
@@ -258,7 +258,22 @@ class Plugin(BasePlugin):
             annotated=args.get("annotated", False),
         )
 
+    # Metadata for UI
     # -----------------------------
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(
+            name=self.name,
+            description=self.description,
+            version=self.version,
+            inputs=["image"],
+            outputs=["json"],
+            config_schema={
+                "device": {"type": "string", "default": "cpu"},
+                "annotated": {"type": "boolean", "default": False},
+                "confidence": {"type": "number", "default": 0.25},
+            },
+        )
+
     # Plugin methods (delegate to module functions)
     # -----------------------------
     def player_detection(self, frame_base64: str, device: str = "cpu", annotated: bool = False):


### PR DESCRIPTION
## Problem

Tests fail:
```
AssertionError: Missing required field: config_schema
```

metadata() method was missing config_schema dict.

## Solution

Add metadata() returning PluginMetadata with:
- name, version, description
- inputs, outputs
- config_schema (device, annotated, confidence)

Fixes TestPluginMetadata tests