### PR TITLE
fix(yolo-tracker): Use correct ToolSchema field names

### DIFF
--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/plugin.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/plugin.py
@@ -193,52 +193,52 @@ class Plugin(BasePlugin):
         self.tools = {
             "player_detection": {
                 "description": "Detect players in a frame",
-                "inputs": {
+                "input_schema": {
                     "frame_base64": {"type": "string"},
                     "device": {"type": "string", "default": "cpu"},
                     "annotated": {"type": "boolean", "default": False},
                 },
-                "outputs": {"result": {"type": "object"}},
+                "output_schema": {"result": {"type": "object"}},
                 "handler": self.player_detection,
             },
             "player_tracking": {
                 "description": "Track players across frames",
-                "inputs": {
+                "input_schema": {
                     "frame_base64": {"type": "string"},
                     "device": {"type": "string", "default": "cpu"},
                     "annotated": {"type": "boolean", "default": False},
                 },
-                "outputs": {"result": {"type": "object"}},
+                "output_schema": {"result": {"type": "object"}},
                 "handler": self.player_tracking,
             },
             "ball_detection": {
                 "description": "Detect the football",
-                "inputs": {
+                "input_schema": {
                     "frame_base64": {"type": "string"},
                     "device": {"type": "string", "default": "cpu"},
                     "annotated": {"type": "boolean", "default": False},
                 },
-                "outputs": {"result": {"type": "object"}},
+                "output_schema": {"result": {"type": "object"}},
                 "handler": self.ball_detection,
             },
             "pitch_detection": {
                 "description": "Detect pitch keypoints",
-                "inputs": {
+                "input_schema": {
                     "frame_base64": {"type": "string"},
                     "device": {"type": "string", "default": "cpu"},
                     "annotated": {"type": "boolean", "default": False},
                 },
-                "outputs": {"result": {"type": "object"}},
+                "output_schema": {"result": {"type": "object"}},
                 "handler": self.pitch_detection,
             },
             "radar": {
                 "description": "Generate radar (bird's-eye) view",
-                "inputs": {
+                "input_schema": {
                     "frame_base64": {"type": "string"},
                     "device": {"type": "string", "default": "cpu"},
                     "annotated": {"type": "boolean", "default": False},
                 },
-                "outputs": {"result": {"type": "object"}},
+                "output_schema": {"result": {"type": "object"}},
                 "handler": self.radar,
             },
         }


### PR DESCRIPTION
## Fix
Changed tool dict fields from 'inputs'/'outputs' to 'input_schema'/'output_schema'.

## Root Cause
Server's ToolSchema validates with Pydantic's extra='forbid', rejecting unknown fields.

## Changes
- inputs → input_schema
- outputs → output_schema

## Testing
- Syntax valid ✓
- Will test on GPU with: RUN_MODEL_TESTS=1 pytest