### PR TITLE
fix(yolo-tracker): Move tools to class-level for loader compatibility

### DIFF
--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/plugin.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/plugin.py
@@ -186,62 +186,60 @@ class Plugin(BasePlugin):
     version: str = "0.2.0"
     description: str = "YOLO-based football analysis plugin"
 
-    def __init__(self):
-        """Initialize plugin with bound method handlers."""
-        super().__init__()
-        # Define tools dict with callable handlers (bound methods)
-        self.tools = {
-            "player_detection": {
-                "description": "Detect players in a frame",
-                "input_schema": {
-                    "frame_base64": {"type": "string"},
-                    "device": {"type": "string", "default": "cpu"},
-                    "annotated": {"type": "boolean", "default": False},
-                },
-                "output_schema": {"result": {"type": "object"}},
-                "handler": self.player_detection,
+    # Class-level tools dict (required by ForgeSyte loader contract)
+    # Handler references are resolved at runtime via getattr(self, tool_name)
+    tools: Dict[str, Dict[str, Any]] = {
+        "player_detection": {
+            "description": "Detect players in a frame",
+            "input_schema": {
+                "frame_base64": {"type": "string"},
+                "device": {"type": "string", "default": "cpu"},
+                "annotated": {"type": "boolean", "default": False},
             },
-            "player_tracking": {
-                "description": "Track players across frames",
-                "input_schema": {
-                    "frame_base64": {"type": "string"},
-                    "device": {"type": "string", "default": "cpu"},
-                    "annotated": {"type": "boolean", "default": False},
-                },
-                "output_schema": {"result": {"type": "object"}},
-                "handler": self.player_tracking,
+            "output_schema": {"result": {"type": "object"}},
+            "handler": None,  # Resolved at runtime
+        },
+        "player_tracking": {
+            "description": "Track players across frames",
+            "input_schema": {
+                "frame_base64": {"type": "string"},
+                "device": {"type": "string", "default": "cpu"},
+                "annotated": {"type": "boolean", "default": False},
             },
-            "ball_detection": {
-                "description": "Detect the football",
-                "input_schema": {
-                    "frame_base64": {"type": "string"},
-                    "device": {"type": "string", "default": "cpu"},
-                    "annotated": {"type": "boolean", "default": False},
-                },
-                "output_schema": {"result": {"type": "object"}},
-                "handler": self.ball_detection,
+            "output_schema": {"result": {"type": "object"}},
+            "handler": None,  # Resolved at runtime
+        },
+        "ball_detection": {
+            "description": "Detect the football",
+            "input_schema": {
+                "frame_base64": {"type": "string"},
+                "device": {"type": "string", "default": "cpu"},
+                "annotated": {"type": "boolean", "default": False},
             },
-            "pitch_detection": {
-                "description": "Detect pitch keypoints",
-                "input_schema": {
-                    "frame_base64": {"type": "string"},
-                    "device": {"type": "string", "default": "cpu"},
-                    "annotated": {"type": "boolean", "default": False},
-                },
-                "output_schema": {"result": {"type": "object"}},
-                "handler": self.pitch_detection,
+            "output_schema": {"result": {"type": "object"}},
+            "handler": None,  # Resolved at runtime
+        },
+        "pitch_detection": {
+            "description": "Detect pitch keypoints",
+            "input_schema": {
+                "frame_base64": {"type": "string"},
+                "device": {"type": "string", "default": "cpu"},
+                "annotated": {"type": "boolean", "default": False},
             },
-            "radar": {
-                "description": "Generate radar (bird's-eye) view",
-                "input_schema": {
-                    "frame_base64": {"type": "string"},
-                    "device": {"type": "string", "default": "cpu"},
-                    "annotated": {"type": "boolean", "default": False},
-                },
-                "output_schema": {"result": {"type": "object"}},
-                "handler": self.radar,
+            "output_schema": {"result": {"type": "object"}},
+            "handler": None,  # Resolved at runtime
+        },
+        "radar": {
+            "description": "Generate radar (bird's-eye) view",
+            "input_schema": {
+                "frame_base64": {"type": "string"},
+                "device": {"type": "string", "default": "cpu"},
+                "annotated": {"type": "boolean", "default": False},
             },
-        }
+            "output_schema": {"result": {"type": "object"}},
+            "handler": None,  # Resolved at runtime
+        },
+    }
 
     # -----------------------------
     # MCP dispatcher

--- a/plugins/forgesyte-yolo-tracker/src/tests/test_plugin_schema.py
+++ b/plugins/forgesyte-yolo-tracker/src/tests/test_plugin_schema.py
@@ -18,6 +18,12 @@ from forgesyte_yolo_tracker.plugin import Plugin
 class TestPluginInstantiation:
     """Test plugin loads and initializes correctly."""
 
+    def test_plugin_class_level_tools(self) -> None:
+        """Verify plugin defines tools as class attribute (ForgeSyte loader contract)."""
+        assert hasattr(Plugin, "tools"), "Plugin must define class-level `tools`"
+        assert isinstance(Plugin.tools, dict), "Class-level tools must be a dict"
+        assert len(Plugin.tools) > 0, "Class-level tools must have at least one tool"
+
     def test_plugin_instantiates(self) -> None:
         """Verify plugin can be instantiated."""
         plugin = Plugin()
@@ -61,13 +67,14 @@ class TestToolsSchema:
             assert "output_schema" in actual_fields, f"Tool '{tool_name}' missing 'output_schema'"
 
     def test_tools_have_handler_callables(self, plugin: Plugin) -> None:
-        """Verify all tools have callable handlers."""
+        """Verify all tools have callable handlers (or None for runtime resolution)."""
         for tool_name, tool_meta in plugin.tools.items():
             assert "handler" in tool_meta, f"Tool '{tool_name}' missing handler"
             handler = tool_meta["handler"]
-            assert callable(handler), (
-                f"Tool '{tool_name}' handler must be callable, "
-                f"got {type(handler)} (not string)"
+            # Handler can be None (resolved at runtime via getattr) or callable
+            assert handler is None or callable(handler), (
+                f"Tool '{tool_name}' handler must be None or callable, "
+                f"got {type(handler)}"
             )
 
     def test_tools_schema_json_serializable(self, plugin: Plugin) -> None:


### PR DESCRIPTION
## Problem
Unit tests pass but server loader rejects plugin with 'Plugin must define a dict attribute tools'.

## Root Cause
- Plugin defined tools in __init__ (instance-level)
- ForgeSyte loader validates class-level tools before instantiation
- Mismatch caused loader rejection despite valid instance behavior

## Solution
- Move tools dict from __init__ to class attribute
- Handler values set to None (resolved at runtime)
- Add test validating class-level tools

## Result
✅ Loader sees Plugin.tools before instantiation
✅ Instance still dispatches via getattr(self, tool_name) 
✅ 31/31 tests pass
✅ Plugin now loadable on server

## Files Changed
- plugin.py: Restructured class layout
- test_plugin_schema.py: Added class-level validation, updated handler test