### PR TITLE
fix(yolo-tracker): Handler method names as strings per loader contract

### DIFF
--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/plugin.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/plugin.py
@@ -187,7 +187,7 @@ class Plugin(BasePlugin):
     description: str = "YOLO-based football analysis plugin"
 
     # Class-level tools dict (required by ForgeSyte loader contract)
-    # Handler references are resolved at runtime via getattr(self, tool_name)
+    # Handler names are strings, resolved at runtime via getattr(self, handler_name)
     tools: Dict[str, Dict[str, Any]] = {
         "player_detection": {
             "description": "Detect players in a frame",
@@ -197,7 +197,7 @@ class Plugin(BasePlugin):
                 "annotated": {"type": "boolean", "default": False},
             },
             "output_schema": {"result": {"type": "object"}},
-            "handler": None,  # Resolved at runtime
+            "handler": "player_detection",
         },
         "player_tracking": {
             "description": "Track players across frames",
@@ -207,7 +207,7 @@ class Plugin(BasePlugin):
                 "annotated": {"type": "boolean", "default": False},
             },
             "output_schema": {"result": {"type": "object"}},
-            "handler": None,  # Resolved at runtime
+            "handler": "player_tracking",
         },
         "ball_detection": {
             "description": "Detect the football",
@@ -217,7 +217,7 @@ class Plugin(BasePlugin):
                 "annotated": {"type": "boolean", "default": False},
             },
             "output_schema": {"result": {"type": "object"}},
-            "handler": None,  # Resolved at runtime
+            "handler": "ball_detection",
         },
         "pitch_detection": {
             "description": "Detect pitch keypoints",
@@ -227,7 +227,7 @@ class Plugin(BasePlugin):
                 "annotated": {"type": "boolean", "default": False},
             },
             "output_schema": {"result": {"type": "object"}},
-            "handler": None,  # Resolved at runtime
+            "handler": "pitch_detection",
         },
         "radar": {
             "description": "Generate radar (bird's-eye) view",
@@ -237,7 +237,7 @@ class Plugin(BasePlugin):
                 "annotated": {"type": "boolean", "default": False},
             },
             "output_schema": {"result": {"type": "object"}},
-            "handler": None,  # Resolved at runtime
+            "handler": "radar",
         },
     }
 

--- a/plugins/forgesyte-yolo-tracker/src/tests/test_plugin_schema.py
+++ b/plugins/forgesyte-yolo-tracker/src/tests/test_plugin_schema.py
@@ -66,15 +66,19 @@ class TestToolsSchema:
             assert "input_schema" in actual_fields, f"Tool '{tool_name}' missing 'input_schema'"
             assert "output_schema" in actual_fields, f"Tool '{tool_name}' missing 'output_schema'"
 
-    def test_tools_have_handler_callables(self, plugin: Plugin) -> None:
-        """Verify all tools have callable handlers (or None for runtime resolution)."""
+    def test_tools_have_handler_strings(self, plugin: Plugin) -> None:
+        """Verify all tools have handler method names as strings (ForgeSyte loader contract)."""
         for tool_name, tool_meta in plugin.tools.items():
             assert "handler" in tool_meta, f"Tool '{tool_name}' missing handler"
             handler = tool_meta["handler"]
-            # Handler can be None (resolved at runtime via getattr) or callable
-            assert handler is None or callable(handler), (
-                f"Tool '{tool_name}' handler must be None or callable, "
+            # Handler must be a string name, resolved at runtime via getattr(self, handler)
+            assert isinstance(handler, str), (
+                f"Tool '{tool_name}' handler must be a string (method name), "
                 f"got {type(handler)}"
+            )
+            # Verify the handler method exists on the plugin instance
+            assert hasattr(plugin, handler), (
+                f"Tool '{tool_name}' references handler '{handler}' which doesn't exist"
             )
 
     def test_tools_schema_json_serializable(self, plugin: Plugin) -> None:


### PR DESCRIPTION
## Root Cause
ForgeSyte loader validates handlers BEFORE instantiation. It requires handler field to be a STRING (method name), not None or callable.

## Problem
Plugin had:
```python
'handler': None  # Resolved at runtime
```

Loader behavior:
- Sees None → discards it → replaces with None
- Handler becomes null → validation fails

## Solution  
Plugin now has:
```python
'handler': 'player_detection'
'handler': 'player_tracking'
...
```

Loader behavior:
- Sees string → resolves via getattr(plugin, 'player_detection')
- Returns method → validation passes
- Plugin loads successfully

## Testing
✅ 31 tests pass
✅ Handler string validation
✅ Method existence checks

## Files
- plugin.py: All handlers as method name strings
- test_plugin_schema.py: Updated to validate strings, not None