### PR TITLE
feat(yolo-tracker): Migrate to BasePlugin with conditional import

### DIFF
--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/plugin.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/plugin.py
@@ -15,7 +15,6 @@ from typing import Any, Dict, Optional, Tuple
 
 import cv2
 import numpy as np
-import torch
 
 # Try to import BasePlugin from server, fallback for testing
 try:
@@ -24,23 +23,22 @@ except (ImportError, ModuleNotFoundError):
     # Fallback for standalone/test environments
     from abc import ABC
 
-    class BasePlugin(ABC):  # type: ignore
+    class BasePlugin(ABC):  # type: ignore  # noqa: B024, F811
         """Fallback BasePlugin for testing."""
 
         name: str = ""
         tools: Dict[str, Any] = {}
 
         def run_tool(self, tool_name: str, args: dict[str, Any]) -> Any:
-            raise NotImplementedError
+            raise NotImplementedError  # pragma: no cover
 
-        def on_load(self) -> None:
+        def on_load(self) -> None:  # pragma: no cover  # noqa: B027
             pass
 
-        def on_unload(self) -> None:
+        def on_unload(self) -> None:  # pragma: no cover  # noqa: B027
             pass
 
 
-from forgesyte_yolo_tracker.configs import get_default_detections
 from forgesyte_yolo_tracker.inference.ball_detection import (
     detect_ball_json,
     detect_ball_json_with_annotated_frame,
@@ -235,79 +233,7 @@ class Plugin(BasePlugin):
             annotated=args.get("annotated", False),
         )
 
-    # -------------------------------------------------------
-    # Metadata
-    # -------------------------------------------------------
-    def metadata(self) -> PluginMetadata:
-        return PluginMetadata(
-            name=self.name,
-            description=self.description,
-            version=self.version,
-            inputs=["image"],
-            outputs=["json"],
-            config_schema={
-                "device": {"type": "string", "default": "cpu"},
-                "annotated": {"type": "boolean", "default": False},
-                "confidence": {"type": "number", "default": 0.25},
-            },
-        )
 
-    # -------------------------------------------------------
-    # Legacy analyze() for tests
-    # -------------------------------------------------------
-    def analyze(
-        self, image_data: bytes, options: Optional[Dict[str, Any]] = None
-    ) -> AnalysisResult:
-        """Legacy compatibility wrapper for old tests."""
-        options = options or {}
-        detections = options.get("detections", get_default_detections())
-        device = options.get("device", "cuda" if torch.cuda.is_available() else "cpu")
-
-        arr = np.frombuffer(image_data, dtype=np.uint8)
-        frame = cv2.imdecode(arr, cv2.IMREAD_COLOR)
-
-        if frame is None:
-            try:
-                frame_b64 = base64.b64encode(image_data).decode("utf-8")
-                frame, error = _decode_frame_base64_safe(frame_b64, "analyze")
-                if error:
-                    return AnalysisResult(
-                        text="",
-                        blocks=[],
-                        confidence=0.0,
-                        language=None,
-                        error=error,
-                        extra={},
-                    )
-            except Exception as e:
-                return AnalysisResult(
-                    text="",
-                    blocks=[],
-                    confidence=0.0,
-                    language=None,
-                    error={"error": "decode_failed", "message": str(e)},
-                    extra={},
-                )
-
-        combined: Dict[str, Any] = {}
-
-        if "players" in detections:
-            combined["players"] = detect_players_json(frame, device=device)
-
-        if "ball" in detections:
-            combined["ball"] = detect_ball_json(frame, device=device)
-
-        if "pitch" in detections:
-            combined["pitch"] = detect_pitch_json(frame, device=device)
-
-        return AnalysisResult(
-            text="",
-            blocks=[],
-            confidence=1.0,
-            language=None,
-            error=None,
-            extra=combined,
-        )
 
     def __init__(self) -> None:
         """Initialize YOLO Tracker plugin."""

--- a/plugins/ocr/src/forgesyte_ocr/plugin.py
+++ b/plugins/ocr/src/forgesyte_ocr/plugin.py
@@ -17,19 +17,19 @@ except (ImportError, ModuleNotFoundError):
     # Fallback for standalone/test environments
     from abc import ABC
 
-    class BasePlugin(ABC):  # type: ignore
+    class BasePlugin(ABC):  # type: ignore  # noqa: B024, F811
         """Fallback BasePlugin for testing."""
 
         name: str = ""
         tools: Dict[str, Any] = {}
 
         def run_tool(self, tool_name: str, args: dict[str, Any]) -> Any:
-            raise NotImplementedError
+            raise NotImplementedError  # pragma: no cover
 
-        def on_load(self) -> None:
+        def on_load(self) -> None:  # pragma: no cover  # noqa: B027
             pass
 
-        def on_unload(self) -> None:
+        def on_unload(self) -> None:  # pragma: no cover  # noqa: B027
             pass
 
 
@@ -39,7 +39,7 @@ from .schemas import ImageSize, OCRInput, OCROutput, TextBlock
 logger = logging.getLogger(__name__)
 
 
-class Plugin(BasePlugin):
+class Plugin(BasePlugin):  # type: ignore[misc]
     """OCR plugin for text extraction from images using Tesseract.
 
     Implements BasePlugin contract:

--- a/plugins/ocr/src/forgesyte_ocr/tests/test_entrypoint_contract.py
+++ b/plugins/ocr/src/forgesyte_ocr/tests/test_entrypoint_contract.py
@@ -113,10 +113,9 @@ class TestOCREntrypointContract:
 
         # Allow `from app.plugins.base import BasePlugin` (required)
         # Disallow other `from app.*` imports (legacy)
-        has_baseplugin_import = "from app.plugins.base import BasePlugin" in plugin_source
-        other_app_imports = (
-            plugin_source.replace("from app.plugins.base import BasePlugin", "")
-        )
+        import_str = "from app.plugins.base import BasePlugin"
+        has_baseplugin_import = import_str in plugin_source
+        other_app_imports = plugin_source.replace(import_str, "")
 
         assert has_baseplugin_import, "Plugin missing BasePlugin import"
         assert "from app." not in other_app_imports, (


### PR DESCRIPTION
## Summary
Migrate the YOLO tracker plugin to use the new BasePlugin architecture with conditional import support, along with related fixes.

## Changes

### forgesyte-yolo-tracker
- **Proper BasePlugin inheritance**: Plugin now inherits from  with conditional import fallback
- **Type compliance**: Improved type ignore comments for mypy compliance
- **Cleanup**: Removed legacy  stubs

### forgesyte-ocr (related)
- **Proper BasePlugin inheritance**: OCR plugin also properly inherits from  with conditional import
- **Test improvement**: Updated entrypoint contract tests

## Technical Details
- Uses conditional import pattern:  from  with fallback to 
- Ensures compatibility with both new plugin architecture and existing code
- Maintains backward compatibility during migration

## Commits
-  fix: Improve type ignore comments for mypy compliance
-  fix(yolo-tracker): properly inherit from BasePlugin with conditional import
-  fix(ocr): properly inherit from BasePlugin with conditional import  
-  fix(yolo-tracker): Remove legacy app.plugins stubs