### PR TITLE
fix(ocr): Fix line length linting error in plugin docstring

### DIFF
--- a/plugins/ocr/src/forgesyte_ocr/plugin.py
+++ b/plugins/ocr/src/forgesyte_ocr/plugin.py
@@ -73,7 +73,8 @@ class Plugin(BasePlugin):  # type: ignore[misc]
         """Execute a tool by name with the given arguments.
 
         Args:
-            tool_name: Name of tool to execute (accepts "default" as alias for "analyze")
+            tool_name: Name of tool to execute. Accepts "default" as alias
+                for "analyze" for backward compatibility.
             args: Tool arguments dict
 
         Returns:


### PR DESCRIPTION
## Problem
Pre-commit linting detected line 76 exceeds 88 character limit.

## Solution
Split long docstring line into multiple lines.

## Verification
- ✅ Pre-commit run locally: PASSED
- ✅ Line length now compliant: 88 characters

## Changes
- Modified docstring in run_tool() method
- Split into multiple lines for readability