### PR TITLE
fix(yolo-tracker): Accept 'default' as tool alias

### DIFF
--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/plugin.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/plugin.py
@@ -40,17 +40,23 @@ except (ImportError, ModuleNotFoundError):
 
 
 from forgesyte_yolo_tracker.inference.ball_detection import (
-    detect_ball_json, detect_ball_json_with_annotated_frame)
+    detect_ball_json,
+    detect_ball_json_with_annotated_frame,
+)
 from forgesyte_yolo_tracker.inference.pitch_detection import (
-    detect_pitch_json, detect_pitch_json_with_annotated_frame)
+    detect_pitch_json,
+    detect_pitch_json_with_annotated_frame,
+)
 from forgesyte_yolo_tracker.inference.player_detection import (
-    detect_players_json, detect_players_json_with_annotated_frame)
+    detect_players_json,
+    detect_players_json_with_annotated_frame,
+)
 from forgesyte_yolo_tracker.inference.player_tracking import (
-    track_players_json, track_players_json_with_annotated_frame)
-from forgesyte_yolo_tracker.inference.radar import \
-    generate_radar_json as radar_json
-from forgesyte_yolo_tracker.inference.radar import \
-    radar_json_with_annotated_frame
+    track_players_json,
+    track_players_json_with_annotated_frame,
+)
+from forgesyte_yolo_tracker.inference.radar import generate_radar_json as radar_json
+from forgesyte_yolo_tracker.inference.radar import radar_json_with_annotated_frame
 
 logger = logging.getLogger(__name__)
 
@@ -167,8 +173,7 @@ def _tool_radar(frame_base64: str, device: str = "cpu", annotated: bool = False)
 def _tool_player_detection_video(
     video_path: str, output_path: str, device: str = "cpu"
 ) -> Dict[str, str]:
-    from forgesyte_yolo_tracker.video.player_detection_video import \
-        run_player_detection_video
+    from forgesyte_yolo_tracker.video.player_detection_video import run_player_detection_video
 
     run_player_detection_video(video_path, output_path, device=device)
     return {"status": "success", "output_path": output_path}
@@ -177,8 +182,7 @@ def _tool_player_detection_video(
 def _tool_player_tracking_video(
     video_path: str, output_path: str, device: str = "cpu"
 ) -> Dict[str, str]:
-    from forgesyte_yolo_tracker.video.player_tracking_video import \
-        run_player_tracking_video
+    from forgesyte_yolo_tracker.video.player_tracking_video import run_player_tracking_video
 
     run_player_tracking_video(video_path, output_path, device=device)
     return {"status": "success", "output_path": output_path}
@@ -187,8 +191,7 @@ def _tool_player_tracking_video(
 def _tool_ball_detection_video(
     video_path: str, output_path: str, device: str = "cpu"
 ) -> Dict[str, str]:
-    from forgesyte_yolo_tracker.video.ball_detection_video import \
-        run_ball_detection_video
+    from forgesyte_yolo_tracker.video.ball_detection_video import run_ball_detection_video
 
     run_ball_detection_video(video_path, output_path, device=device)
     return {"status": "success", "output_path": output_path}
@@ -197,8 +200,7 @@ def _tool_ball_detection_video(
 def _tool_pitch_detection_video(
     video_path: str, output_path: str, device: str = "cpu"
 ) -> Dict[str, str]:
-    from forgesyte_yolo_tracker.video.pitch_detection_video import \
-        run_pitch_detection_video
+    from forgesyte_yolo_tracker.video.pitch_detection_video import run_pitch_detection_video
 
     run_pitch_detection_video(video_path, output_path, device=device)
     return {"status": "success", "output_path": output_path}
@@ -330,6 +332,23 @@ class Plugin(BasePlugin):  # type: ignore[misc]
     # Dispatcher
     # -------------------------------------------------------
     def run_tool(self, tool_name: str, args: Dict[str, Any]) -> Any:
+        """Execute a tool by name with the given arguments.
+
+        Args:
+            tool_name: Name of tool to execute. Accepts "default" as alias
+                for first available tool for backward compatibility (Issue #164).
+            args: Tool arguments dict
+
+        Returns:
+            Tool result (dict with detections/keypoints/etc)
+
+        Raises:
+            ValueError: If tool name not found
+        """
+        # Accept "default" as alias for first tool (backward compatibility - Issue #164)
+        if tool_name == "default":
+            tool_name = next(iter(self.tools.keys()))
+
         if tool_name not in self.tools:
             raise ValueError(f"Unknown tool: {tool_name}")
 

--- a/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/utils/team.py
+++ b/plugins/forgesyte-yolo-tracker/src/forgesyte_yolo_tracker/utils/team.py
@@ -65,8 +65,7 @@ class TeamClassifier:
             self.reducer = umap.UMAP(n_components=3)
         else:
             # Fallback: use a simple scaler if umap is not available
-            from sklearn.preprocessing import \
-                StandardScaler  # type: ignore[import]
+            from sklearn.preprocessing import StandardScaler  # type: ignore[import]
 
             self.reducer = StandardScaler()  # type: ignore[assignment]
         self.cluster_model = KMeans(n_clusters=2)

--- a/plugins/forgesyte-yolo-tracker/tests_contract/test_default_tool_alias.py
+++ b/plugins/forgesyte-yolo-tracker/tests_contract/test_default_tool_alias.py
@@ -1,0 +1,65 @@
+"""TEST-CHANGE: Test that YOLO-tracker accepts 'default' as tool alias.
+
+Issue #164: Plugin should accept 'default' as alias for first available tool
+for backward compatibility.
+"""
+
+import pytest
+
+from forgesyte_yolo_tracker.plugin import Plugin
+
+
+class TestDefaultToolAlias:
+    """Tests for 'default' tool alias fallback."""
+
+    def test_run_tool_accepts_default_alias_maps_to_first_tool(self) -> None:
+        """Verify run_tool accepts 'default' and maps to first available tool.
+        
+        This test will FAIL before the fix is applied because plugin.run_tool()
+        will raise ValueError("Unknown tool: default").
+        
+        After fix: 'default' should map to first tool in plugin.tools.
+        """
+        plugin = Plugin()
+        
+        # Get first tool name
+        first_tool_name = next(iter(plugin.tools.keys()))
+        
+        # Create minimal args for any tool
+        test_args = {
+            "frame_base64": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+            "device": "cpu",
+            "annotated": False,
+        }
+        
+        # This should NOT raise - "default" should work as alias
+        try:
+            # Try calling with "default" - should use first tool
+            result = plugin.run_tool("default", test_args)
+            # If we get here, the fix works
+            assert result is not None
+        except ValueError as e:
+            if "Unknown tool: default" in str(e):
+                pytest.fail(
+                    f"Plugin.run_tool() should accept 'default' as alias for '{first_tool_name}' "
+                    f"but got error: {e}. Fix needed in plugin.py run_tool()."
+                )
+            raise
+
+    def test_plugin_has_explicit_tools_not_default(self) -> None:
+        """Verify plugin doesn't have literal 'default' tool - explains why alias needed."""
+        plugin = Plugin()
+        
+        # YOLO-tracker uses explicit tool names
+        assert "default" not in plugin.tools
+        
+        # Should have real tools
+        assert len(plugin.tools) > 0
+        first_tool = next(iter(plugin.tools.keys()))
+        assert first_tool in {
+            "player_detection",
+            "player_tracking",
+            "ball_detection", 
+            "pitch_detection",
+            "radar",
+        }


### PR DESCRIPTION
## TDD: Failing Test → Fix → Passing Test

**Step 1: Failing Test (Before Fix)**
✅ Created test_default_tool_alias.py
✅ Ran test - FAILED with: ValueError: Unknown tool: default

**Step 2: Apply Fix**
✅ Modified plugin.py run_tool() to accept 'default' alias
✅ Maps 'default' to first tool in plugin.tools

**Step 3: Passing Test (After Fix)**
✅ Ran tests - 85/85 PASSED (all contract tests)

## Quality Checks

✅ All contract tests: 85/85 pass
✅ Ruff: pass
✅ Black: pass

## Why This Fix

- Server now sends correct tool_name (forgesyte fix)
- Plugin accepts 'default' fallback (this PR - defense in depth)
- Matches OCR plugin behavior (commit 41f3c6e)
- YOLO-tracker uses explicit tool names, not 'default'

Closes #164