### PR TITLE
chore(ci): Update forgesyte-plugins CI workflow

### DIFF
--- a/.github/workflows/forgesyte-plugins-ci.yml
+++ b/.github/workflows/forgesyte-plugins-ci.yml
@@ -5,10 +5,11 @@ on:
     paths:
       - "plugins/**/manifest.json"
       - "validate_manifest.py"
+
   push:
     branches: [ main ]
     paths:
-      - "plugins/**/manifest.json"
+      - "plugins/**"
       - "validate_manifest.py"
 
 jobs:
@@ -132,3 +133,5 @@ jobs:
             uv run mypy src/ --config-file ../../mypy.ini
             cd - > /dev/null
           done
+
+


### PR DESCRIPTION
## **PR Message**

**Summary**  
This PR updates the CI workflow triggers so that plugin‑related changes reliably run the ForgeSyte Plugins CI after merging into `main`.

**What changed**  
- Expanded the `push` trigger path filter from:  
  - `plugins/**/manifest.json`  
  - `validate_manifest.py`  
- To the broader:  
  - `plugins/**`  
  - `validate_manifest.py`

**Why**  
GitHub does not fire `pull_request` workflows on merge commits, and merge commits often contain no file‑level diffs. Because the previous `push` filter only matched manifest files, CI did not run when a PR was merged unless the merge commit itself modified a manifest.  
By widening the filter to `plugins/**`, any plugin‑related change now correctly triggers CI on merge.

**Result**  
- PR validation behavior remains unchanged  
- CI now runs consistently on merges involving plugin changes  
- No unnecessary runs on unrelated files

